### PR TITLE
Install in a local folder instead of /opt/

### DIFF
--- a/bin/catppuccinifier
+++ b/bin/catppuccinifier
@@ -16,19 +16,19 @@ try:
     
     if flavor == "latte":
         print("Generating...")
-        command = "cd {} ; magick {} /opt/catppuccinifier/flavors/latte-hald-clut.png -hald-clut {}-{}".format(currentDirectory, image, flavor, image)
+        command = "cd {} ; magick {} ~/.local/share/catppuccinifier/flavors/latte-hald-clut.png -hald-clut {}-{}".format(currentDirectory, image, flavor, image)
 
     elif flavor == "frappe":
         print("Generating...")
-        command = "cd {} ; magick {} /opt/catppuccinifier/flavors/frappe-hald-clut.png -hald-clut {}-{}".format(currentDirectory, image, flavor, image)
+        command = "cd {} ; magick {} ~/.local/share/catppuccinifier/flavors/frappe-hald-clut.png -hald-clut {}-{}".format(currentDirectory, image, flavor, image)
 
     elif flavor == "macchiato":
         print("Generating...")
-        command = "cd {} ; magick {} /opt/catppuccinifier/flavors/macchiato-hald-clut.png -hald-clut {}-{}".format(currentDirectory, image, flavor, image)
+        command = "cd {} ; magick {} ~/.local/share/catppuccinifier/flavors/macchiato-hald-clut.png -hald-clut {}-{}".format(currentDirectory, image, flavor, image)
 
     elif flavor == "mocha":
         print("Generating...")
-        command = "cd {} ; magick {} /opt/catppuccinifier/flavors/mocha-hald-clut.png -hald-clut {}-{}".format(currentDirectory, image, flavor, image)
+        command = "cd {} ; magick {} ~/.local/share/catppuccinifier/flavors/mocha-hald-clut.png -hald-clut {}-{}".format(currentDirectory, image, flavor, image)
 
     else:
         command = None

--- a/install.sh
+++ b/install.sh
@@ -12,12 +12,12 @@ elif ! which magick >/dev/null; then
 
 else
 
-    if ! [ -d /opt/catppuccinifier/ ]; then
+    if ! [ -d ~/.local/share/catppuccinifier/ ]; then
 
-        sudo mkdir /opt/catppuccinifier
+        sudo mkdir ~/.local/share/catppuccinifier
     fi
 
-    sudo cp -p -r $SCRIPT_DIR/src/flavors/ /opt/catppuccinifier/
+    sudo cp -p -r $SCRIPT_DIR/src/flavors/ ~/.local/share/catppuccinifier/
 
     sudo cp -p $SCRIPT_DIR/bin/catppuccinifier /usr/local/bin/
 fi


### PR DESCRIPTION
```
magick: unable to open image '/opt/catppuccinifier/flavors/frappe-hald-clut.png': No such file or directory @ error/blob.c/OpenBlob/3569.

pm  …/catppuccinifier   master   ♥ 12:02  cd /opt/catppuccinifier/                                

pm  /opt/catppuccinifier  ♥ 12:02  ls  
 flavors

pm  /opt/catppuccinifier  ♥ 12:02  cd flavors              

pm  /opt/catppuccinifier/flavors  ♥ 12:02  ls
 frappe-hald-clut.png   latte-hald-clut.png   macchiato-hald-clut.png   mocha-hald-clut.png
```
I don’t really know why the reference palettes files should be placed outside a local directory, as it causes non-root users to be unable to access them.
I’ve settled for `~/.local/share/catppuccinifier/` but I believe it could also be moved alongside the executable (Which could have also been moved to `~/.local/bin/` for more consistency) to `/usr/local/catppuccinifier`.